### PR TITLE
DOTORG-839 Added OAuth2 settings for Blackbaud

### DIFF
--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/constants.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/constants.ts
@@ -1,1 +1,2 @@
 export const SKY_API_BASE_URL = 'https://api.sky.blackbaud.com/constituent/v1'
+export const SKY_OAUTH2_TOKEN_URL = 'https://oauth2.sky.blackbaud.com/token'

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/index.ts
@@ -1,7 +1,12 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+import { SKY_OAUTH2_TOKEN_URL } from './constants'
 
 import createOrUpdateIndividualConstituent from './createOrUpdateIndividualConstituent'
+
+interface RefreshTokenResponse {
+  access_token: string
+}
 
 const destination: DestinationDefinition<Settings> = {
   name: "Blackbaud Raiser's Edge NXT",
@@ -19,23 +24,27 @@ const destination: DestinationDefinition<Settings> = {
     },
     refreshAccessToken: async (request, { auth }) => {
       // Return a request that refreshes the access_token if the API supports it
-      const res = await request('https://oauth2.sky.blackbaud.com/token', {
+      const res = await request<RefreshTokenResponse>(SKY_OAUTH2_TOKEN_URL, {
         method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded'
+        },
         body: new URLSearchParams({
+          grant_type: 'refresh_token',
           refresh_token: auth.refreshToken,
           client_id: auth.clientId,
-          client_secret: auth.clientSecret,
-          grant_type: 'refresh_token'
+          client_secret: auth.clientSecret
         })
       })
 
-      return { accessToken: res.body.access_token }
+      return { accessToken: res.data.access_token }
     }
   },
   extendRequest({ auth }) {
     return {
       headers: {
-        authorization: `Bearer ${auth?.accessToken}`
+        authorization: `Bearer ${auth?.accessToken}`,
+        'Bb-Api-Subscription-Key': `${auth?.bb_api_subscription_key}`
       }
     }
   },

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/index.ts
@@ -26,9 +26,6 @@ const destination: DestinationDefinition<Settings> = {
       // Return a request that refreshes the access_token if the API supports it
       const res = await request<RefreshTokenResponse>(SKY_OAUTH2_TOKEN_URL, {
         method: 'POST',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded'
-        },
         body: new URLSearchParams({
           grant_type: 'refresh_token',
           refresh_token: auth.refreshToken,


### PR DESCRIPTION
Added OAuth2 Settings for Blackbaud API based on example here: https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/google-sheets-dev/index.ts 

Related documentation: https://developer.blackbaud.com/skyapi/docs/authorization/auth-code-flow/tutorial#refresh-access-token 