### PR TITLE
DOTORG-849 Create Constituent Action

### DIFF
--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Testing snapshot for actions-blackbaud-raisers-edge-nxt destination: createConstituentAction action - all fields 1`] = `
+Object {
+  "birthdate": Object {
+    "d": "31",
+    "m": "1",
+    "y": "2021",
+  },
+  "first": "x3tNm3W0",
+  "gender": "x3tNm3W0",
+  "income": "x3tNm3W0",
+  "last": "x3tNm3W0",
+  "lookup_id": "x3tNm3W0",
+}
+`;
+
+exports[`Testing snapshot for actions-blackbaud-raisers-edge-nxt destination: createConstituentAction action - required fields 1`] = `
+Object {
+  "lookup_id": "x3tNm3W0",
+}
+`;
+
 exports[`Testing snapshot for actions-blackbaud-raisers-edge-nxt destination: createGift action - all fields 1`] = `
 Object {
   "birthdate": Object {

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`Testing snapshot for actions-blackbaud-raisers-edge-nxt destination: createConstituentAction action - all fields 1`] = `
 Object {
   "birthdate": Object {
-    "d": "31",
-    "m": "1",
+    "d": "1",
+    "m": "2",
     "y": "2021",
   },
   "first": "x3tNm3W0",

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/api/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/api/index.ts
@@ -3,6 +3,7 @@ import { SKY_API_CONSTITUENT_URL, SKY_API_GIFTS_URL } from '../constants'
 import {
   Address,
   Constituent,
+  ConstituentAction,
   CreateConstituentResult,
   Email,
   ExistingAddress,
@@ -551,6 +552,13 @@ export class BlackbaudSkyApi {
     return this.request(`${SKY_API_GIFTS_URL}/gifts`, {
       method: 'post',
       json: giftData
+    })
+  }
+
+  async createConstituentAction(constituentActionData: ConstituentAction): Promise<ModifiedResponse> {
+    return this.request(`${SKY_API_CONSTITUENT_URL}/actions`, {
+      method: 'post',
+      json: constituentActionData
     })
   }
 }

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`Testing snapshot for BlackbaudRaisersEdgeNxt's createConstituentAction destination action: all fields 1`] = `
 Object {
   "birthdate": Object {
-    "d": "31",
-    "m": "1",
+    "d": "1",
+    "m": "2",
     "y": "2021",
   },
   "first": "bUa9Yg9hQ",

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for BlackbaudRaisersEdgeNxt's createConstituentAction destination action: all fields 1`] = `
+Object {
+  "birthdate": Object {
+    "d": "31",
+    "m": "1",
+    "y": "2021",
+  },
+  "first": "bUa9Yg9hQ",
+  "gender": "bUa9Yg9hQ",
+  "income": "bUa9Yg9hQ",
+  "last": "bUa9Yg9hQ",
+  "lookup_id": "bUa9Yg9hQ",
+}
+`;
+
+exports[`Testing snapshot for BlackbaudRaisersEdgeNxt's createConstituentAction destination action: required fields 1`] = `
+Object {
+  "lookup_id": "bUa9Yg9hQ",
+}
+`;

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/__tests__/index.test.ts
@@ -1,0 +1,84 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, IntegrationError } from '@segment/actions-core'
+import Destination from '../../index'
+import { SKY_API_CONSTITUENT_URL } from '../../constants'
+import { trackEventData, trackEventDataNewConstituent, trackEventDataNoConstituent } from '../fixtures'
+
+const testDestination = createTestIntegration(Destination)
+
+const mapping = {
+  constituent_email: {
+    address: {
+      '@path': '$.properties.email'
+    },
+    type: {
+      '@path': '$.properties.emailType'
+    }
+  },
+  constituent_id: {
+    '@path': '$.properties.constituentId'
+  },
+  date: {
+    '@path': '$.timestamp'
+  },
+  category: {
+    '@path': '$.properties.category'
+  }
+}
+
+describe('BlackbaudRaisersEdgeNxt.createConstituentAction', () => {
+  test('should create a new constituent action successfully', async () => {
+    const event = createTestEvent(trackEventData)
+
+    nock(SKY_API_CONSTITUENT_URL).post('/actions').reply(200, {
+      id: '1000'
+    })
+
+    await expect(
+      testDestination.testAction('createConstituentAction', {
+        event,
+        mapping,
+        useDefaultMappings: true
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  test('should create a new constituent and associate action with it', async () => {
+    const event = createTestEvent(trackEventDataNewConstituent)
+
+    nock(SKY_API_CONSTITUENT_URL)
+      .get('/constituents/search?search_field=email_address&search_text=john@example.biz')
+      .reply(200, {
+        count: 0,
+        value: []
+      })
+
+    nock(SKY_API_CONSTITUENT_URL).post('/constituents').reply(200, {
+      id: '456'
+    })
+
+    nock(SKY_API_CONSTITUENT_URL).post('/actions').reply(200, {
+      id: '1001'
+    })
+
+    await expect(
+      testDestination.testAction('createConstituentAction', {
+        event,
+        mapping,
+        useDefaultMappings: true
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  test('should throw an IntegrationError if no constituent provided', async () => {
+    const event = createTestEvent(trackEventDataNoConstituent)
+
+    await expect(
+      testDestination.testAction('createConstituentAction', {
+        event,
+        mapping,
+        useDefaultMappings: true
+      })
+    ).rejects.toThrowError(new IntegrationError('Missing constituent_id value', 'MISSING_REQUIRED_FIELD', 400))
+  })
+})

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'createConstituentAction'
+const destinationSlug = 'BlackbaudRaisersEdgeNxt'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200, {})
+    nock(/.*/).persist().patch(/.*/).reply(200, {})
+    nock(/.*/).persist().post(/.*/).reply(200, {})
+    nock(/.*/).persist().put(/.*/).reply(200, {})
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200, {})
+    nock(/.*/).persist().patch(/.*/).reply(200, {})
+    nock(/.*/).persist().post(/.*/).reply(200, {})
+    nock(/.*/).persist().put(/.*/).reply(200, {})
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/fixtures.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/fixtures.ts
@@ -1,0 +1,31 @@
+import { SegmentEvent } from '@segment/actions-core'
+
+// track events
+export const trackEventData: Partial<SegmentEvent> = {
+  type: 'track',
+  properties: {
+    constituentId: '123',
+    category: 'Task/Other'
+  },
+  timestamp: '2022-12-12T19:11:01.249Z'
+}
+
+export const trackEventDataNewConstituent: Partial<SegmentEvent> = {
+  type: 'track',
+  properties: {
+    email: 'john@example.biz',
+    emailType: 'Personal',
+    firstName: 'John',
+    lastName: 'Doe',
+    category: 'Task/Other'
+  },
+  timestamp: '2022-12-12T19:11:01.249Z'
+}
+
+export const trackEventDataNoConstituent: Partial<SegmentEvent> = {
+  type: 'track',
+  properties: {
+    category: 'Task/Other'
+  },
+  timestamp: '2022-12-12T19:11:01.249Z'
+}

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/generated-types.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/generated-types.ts
@@ -1,0 +1,139 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The ID of the constituent.
+   */
+  constituent_id?: string
+  /**
+   * The action date in ISO-8601 format.
+   */
+  date: string | number
+  /**
+   * The channel or intent of the constituent interaction. Available values are Phone Call, Meeting, Mailing, Email, and Task/Other.
+   */
+  category: string
+  /**
+   * Indicates whether the action is complete.
+   */
+  completed?: boolean
+  /**
+   * The date when the action was completed in ISO-8601 format.
+   */
+  completed_date?: string | number
+  /**
+   * The detailed explanation that elaborates on the action summary.
+   */
+  description?: string
+  /**
+   * The direction of the action. Available values are "Inbound" and "Outbound". The default is Inbound.
+   */
+  direction?: string
+  /**
+   * The end time of the action. Uses 24-hour time in the HH:mm format.
+   */
+  end_time?: string
+  /**
+   * The set of immutable constituent system record IDs for the fundraisers associated with the action.
+   */
+  fundraisers?: string
+  /**
+   * The location of the action. Available values are the entries in the Action Locations table.
+   */
+  location?: string
+  /**
+   * The immutable system record ID of the opportunity associated with the action.
+   */
+  opportunity_id?: string
+  /**
+   * The outcome of the action. Available values are Successful and Unsuccessful.
+   */
+  outcome?: string
+  /**
+   * The priority of the action. Available values are Normal, High, and Low. The default is Normal.
+   */
+  priority?: string
+  /**
+   * The start time of the action. Uses 24-hour time in the HH:mm format.
+   */
+  start_time?: string
+  /**
+   * The action status. If the system is configured to use custom action statuses, available values are the entries in the Action Status table.
+   */
+  status?: string
+  /**
+   * The short description of the action that appears at the top of the record. Character limit: 255.
+   */
+  summary?: string
+  /**
+   * Additional description of the action to complement the category. Available values are the entries in the Actions table.
+   */
+  type?: string
+  /**
+   * The author of the action's summary and description. If not supplied, will have a default set based on the user's account. Character limit: 50.
+   */
+  author?: string
+  /**
+   * The constituent's address.
+   */
+  constituent_address?: {
+    address_lines?: string
+    city?: string
+    country?: string
+    do_not_mail?: boolean
+    postal_code?: string
+    primary?: boolean
+    state?: string
+    type?: string
+  }
+  /**
+   * The constituent's birthdate.
+   */
+  constituent_birthdate?: string | number
+  /**
+   * The constituent's email address.
+   */
+  constituent_email?: {
+    address?: string
+    do_not_email?: boolean
+    primary?: boolean
+    type?: string
+  }
+  /**
+   * The constituent's first name up to 50 characters.
+   */
+  constituent_first?: string
+  /**
+   * The constituent's gender.
+   */
+  constituent_gender?: string
+  /**
+   * The constituent's income.
+   */
+  constituent_income?: string
+  /**
+   * The constituent's last name up to 100 characters. This is required to create a constituent.
+   */
+  constituent_last?: string
+  /**
+   * The organization-defined identifier for the constituent.
+   */
+  constituent_lookup_id?: string
+  /**
+   * The constituent's online presence.
+   */
+  constituent_online_presence?: {
+    address?: string
+    primary?: boolean
+    type?: string
+  }
+  /**
+   * The constituent's phone number.
+   */
+  constituent_phone?: {
+    do_not_call?: boolean
+    number?: string
+    primary?: boolean
+    type?: string
+  }
+}

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/generated-types.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/generated-types.ts
@@ -26,13 +26,13 @@ export interface Payload {
    */
   direction?: string
   /**
-   * The end time of the action. Uses 24-hour time in the HH:mm format.
+   * The end time of the action. Uses 24-hour time in the HH:mm format. For example, 17:30 represents 5:30 p.m.
    */
   end_time?: string
   /**
    * The set of immutable constituent system record IDs for the fundraisers associated with the action.
    */
-  fundraisers?: string
+  fundraisers?: string[]
   /**
    * The location of the action. Available values are the entries in the Action Locations table.
    */
@@ -50,7 +50,7 @@ export interface Payload {
    */
   priority?: string
   /**
-   * The start time of the action. Uses 24-hour time in the HH:mm format.
+   * The start time of the action. Uses 24-hour time in the HH:mm format. For example, 17:30 represents 5:30 p.m.
    */
   start_time?: string
   /**

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/generated-types.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/generated-types.ts
@@ -2,10 +2,6 @@
 
 export interface Payload {
   /**
-   * The ID of the constituent.
-   */
-  constituent_id?: string
-  /**
    * The action date in ISO-8601 format.
    */
   date: string | number
@@ -90,6 +86,10 @@ export interface Payload {
    * The constituent's birthdate.
    */
   constituent_birthdate?: string | number
+  /**
+   * The ID of the constituent.
+   */
+  constituent_id?: string
   /**
    * The constituent's email address.
    */

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
@@ -131,7 +131,6 @@ const fields: Record<string, InputField> = augmentFieldsWithConstituentFields({
 })
 
 const perform: RequestFn<Settings, Payload> = async (request, { settings, payload }) => {
-  // Refactor this into a method that createGift can use as well
   const constituentPayload = buildConstituentPayloadFromPayload(payload as StringIndexedObject)
 
   let constituentId = payload.constituent_id

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
@@ -1,15 +1,16 @@
 import { ActionDefinition, ExecuteInput, InputField, IntegrationError, RequestFn } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from '../createConstituentAction/generated-types'
-import {
-  fields as createOrUpdateIndividualConstituentFields,
-  perform as performCreateOrUpdateIndividualConstituent
-} from '../createOrUpdateIndividualConstituent'
+import { perform as performCreateOrUpdateIndividualConstituent } from '../createOrUpdateIndividualConstituent'
 import { BlackbaudSkyApi } from '../api'
 import { ConstituentAction, StringIndexedObject } from '../types'
-import { buildConstituentActionDataFromPayload, buildConstituentPayloadFromPayload } from '../utils'
+import {
+  augmentFieldsWithConstituentFields,
+  buildConstituentActionDataFromPayload,
+  buildConstituentPayloadFromPayload
+} from '../utils'
 
-const fields: Record<string, InputField> = {
+const fields: Record<string, InputField> = augmentFieldsWithConstituentFields({
   date: {
     label: 'Date',
     description: 'The action date in ISO-8601 format.',
@@ -105,19 +106,6 @@ const fields: Record<string, InputField> = {
     description:
       "The author of the action's summary and description. If not supplied, will have a default set based on the user's account. Character limit: 50.",
     type: 'string'
-  }
-}
-
-Object.keys(createOrUpdateIndividualConstituentFields).forEach((key: string) => {
-  let fieldKey = 'constituent_' + key
-  let fieldLabel = 'Constituent ' + createOrUpdateIndividualConstituentFields[key].label
-  if (key === 'constituent_id') {
-    fieldKey = key
-    fieldLabel = createOrUpdateIndividualConstituentFields[key].label
-  }
-  fields[fieldKey] = {
-    ...createOrUpdateIndividualConstituentFields[key],
-    label: fieldLabel
   }
 })
 

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
@@ -10,11 +10,6 @@ import { ConstituentAction, StringIndexedObject } from '../types'
 import { buildConstituentActionDataFromPayload, buildConstituentPayloadFromPayload } from '../utils'
 
 const fields: Record<string, InputField> = {
-  constituent_id: {
-    label: 'Constituent ID',
-    description: 'The ID of the constituent associated with the action.',
-    type: 'string'
-  },
   date: {
     label: 'Date',
     description: 'The action date in ISO-8601 format.',

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
@@ -1,0 +1,161 @@
+import { ActionDefinition, ExecuteInput, InputField, IntegrationError, RequestFn } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from '../createConstituentAction/generated-types'
+import {
+  fields as createOrUpdateIndividualConstituentFields,
+  perform as performCreateOrUpdateIndividualConstituent
+} from '../createOrUpdateIndividualConstituent'
+import { BlackbaudSkyApi } from '../api'
+import { ConstituentAction, StringIndexedObject } from '../types'
+import { buildConstituentActionDataFromPayload, buildConstituentPayloadFromPayload } from '../utils'
+
+const fields: Record<string, InputField> = {
+  constituent_id: {
+    label: 'Constituent ID',
+    description: 'The ID of the constituent associated with the action.',
+    type: 'string'
+  },
+  date: {
+    label: 'Date',
+    description: 'The action date in ISO-8601 format.',
+    type: 'datetime',
+    required: true,
+    default: {
+      '@path': '$.timestamp'
+    }
+  },
+  category: {
+    label: 'Category',
+    description:
+      'The channel or intent of the constituent interaction. Available values are Phone Call, Meeting, Mailing, Email, and Task/Other.',
+    type: 'string',
+    required: true
+  },
+  completed: {
+    label: 'Completed',
+    description: 'Indicates whether the action is complete.',
+    type: 'boolean'
+  },
+  completed_date: {
+    label: 'Completed Date',
+    description: 'The date when the action was completed in ISO-8601 format.',
+    type: 'datetime'
+  },
+  description: {
+    label: 'Description',
+    description: 'The detailed explanation that elaborates on the action summary.',
+    type: 'string'
+  },
+  direction: {
+    label: 'Direction',
+    description: 'The direction of the action. Available values are "Inbound" and "Outbound". The default is Inbound.',
+    type: 'string',
+    default: 'Inbound'
+  },
+  end_time: {
+    label: 'End Time',
+    description: 'The end time of the action. Uses 24-hour time in the HH:mm format.',
+    type: 'string'
+  },
+  fundraisers: {
+    label: 'Fundraisers',
+    description: 'The set of immutable constituent system record IDs for the fundraisers associated with the action.',
+    type: 'string'
+  },
+  location: {
+    label: 'Location',
+    description: 'The location of the action. Available values are the entries in the Action Locations table.',
+    type: 'string'
+  },
+  opportunity_id: {
+    label: 'Opportunity ID',
+    description: 'The immutable system record ID of the opportunity associated with the action.',
+    type: 'string'
+  },
+  outcome: {
+    label: 'Outcome',
+    description: 'The outcome of the action. Available values are Successful and Unsuccessful.',
+    type: 'string'
+  },
+  priority: {
+    label: 'Priority',
+    description: 'The priority of the action. Available values are Normal, High, and Low. The default is Normal.',
+    type: 'string',
+    default: 'Normal'
+  },
+  start_time: {
+    label: 'Start Time',
+    description: 'The start time of the action. Uses 24-hour time in the HH:mm format.',
+    type: 'string'
+  },
+  status: {
+    label: 'Status',
+    description:
+      'The action status. If the system is configured to use custom action statuses, available values are the entries in the Action Status table.',
+    type: 'string'
+  },
+  summary: {
+    label: 'Summary',
+    description: 'The short description of the action that appears at the top of the record. Character limit: 255.',
+    type: 'string'
+  },
+  type: {
+    label: 'Type',
+    description:
+      'Additional description of the action to complement the category. Available values are the entries in the Actions table.',
+    type: 'string'
+  },
+  author: {
+    label: 'Author',
+    description:
+      "The author of the action's summary and description. If not supplied, will have a default set based on the user's account. Character limit: 50.",
+    type: 'string'
+  }
+}
+
+Object.keys(createOrUpdateIndividualConstituentFields).forEach((key: string) => {
+  let fieldKey = 'constituent_' + key
+  let fieldLabel = 'Constituent ' + createOrUpdateIndividualConstituentFields[key].label
+  if (key === 'constituent_id') {
+    fieldKey = key
+    fieldLabel = createOrUpdateIndividualConstituentFields[key].label
+  }
+  fields[fieldKey] = {
+    ...createOrUpdateIndividualConstituentFields[key],
+    label: fieldLabel
+  }
+})
+
+const perform: RequestFn<Settings, Payload> = async (request, { settings, payload }) => {
+  // Refactor this into a method that createGift can use as well
+  const constituentPayload = buildConstituentPayloadFromPayload(payload as StringIndexedObject)
+
+  let constituentId = payload.constituent_id
+  if (Object.keys(constituentPayload).length > 0) {
+    const createOrUpdateIndividualConstituentResponse = await performCreateOrUpdateIndividualConstituent(request, {
+      settings: settings,
+      payload: constituentPayload
+    } as ExecuteInput<Settings, Payload>)
+    constituentId = createOrUpdateIndividualConstituentResponse.id
+  } else if (constituentId === undefined) {
+    throw new IntegrationError('Missing constituent_id value', 'MISSING_REQUIRED_FIELD', 400)
+  }
+
+  const blackbaudSkyApiClient: BlackbaudSkyApi = new BlackbaudSkyApi(request)
+
+  const constituentActionData = buildConstituentActionDataFromPayload(
+    constituentId as string,
+    payload
+  ) as ConstituentAction
+
+  return blackbaudSkyApiClient.createConstituentAction(constituentActionData)
+}
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Create Constituent Action',
+  description: "Create a Constituent Action record in Raiser's Edge NXT.",
+  fields,
+  perform
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createConstituentAction/index.ts
@@ -25,7 +25,14 @@ const fields: Record<string, InputField> = augmentFieldsWithConstituentFields({
     description:
       'The channel or intent of the constituent interaction. Available values are Phone Call, Meeting, Mailing, Email, and Task/Other.',
     type: 'string',
-    required: true
+    required: true,
+    choices: [
+      { label: 'Phone Call', value: 'Phone Call' },
+      { label: 'Meeting', value: 'Meeting' },
+      { label: 'Mailing', value: 'Mailing' },
+      { label: 'Email', value: 'Email' },
+      { label: 'Task/Other', value: 'Task/Other' }
+    ]
   },
   completed: {
     label: 'Completed',
@@ -46,17 +53,22 @@ const fields: Record<string, InputField> = augmentFieldsWithConstituentFields({
     label: 'Direction',
     description: 'The direction of the action. Available values are "Inbound" and "Outbound". The default is Inbound.',
     type: 'string',
-    default: 'Inbound'
+    default: 'Inbound',
+    choices: [
+      { label: 'Inbound', value: 'Inbound' },
+      { label: 'Outbound', value: 'Outbound' }
+    ]
   },
   end_time: {
     label: 'End Time',
-    description: 'The end time of the action. Uses 24-hour time in the HH:mm format.',
+    description: 'The end time of the action. Uses 24-hour time in the HH:mm format. For example, 17:30 represents 5:30 p.m.',
     type: 'string'
   },
   fundraisers: {
     label: 'Fundraisers',
     description: 'The set of immutable constituent system record IDs for the fundraisers associated with the action.',
-    type: 'string'
+    type: 'string',
+    multiple: true
   },
   location: {
     label: 'Location',
@@ -71,17 +83,26 @@ const fields: Record<string, InputField> = augmentFieldsWithConstituentFields({
   outcome: {
     label: 'Outcome',
     description: 'The outcome of the action. Available values are Successful and Unsuccessful.',
-    type: 'string'
+    type: 'string',
+    choices: [
+      { label: 'Successful', value: 'Successful' },
+      { label: 'Unsuccessful', value: 'Unsuccessful' }
+    ]
   },
   priority: {
     label: 'Priority',
     description: 'The priority of the action. Available values are Normal, High, and Low. The default is Normal.',
     type: 'string',
-    default: 'Normal'
+    default: 'Normal',
+    choices: [
+      { label: 'High', value: 'High' },
+      { label: 'Low', value: 'Low' },
+      { label: 'Normal', value: 'Normal' }
+    ]
   },
   start_time: {
     label: 'Start Time',
-    description: 'The start time of the action. Uses 24-hour time in the HH:mm format.',
+    description: 'The start time of the action. Uses 24-hour time in the HH:mm format. For example, 17:30 represents 5:30 p.m.',
     type: 'string'
   },
   status: {

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createGift/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/createGift/index.ts
@@ -1,15 +1,16 @@
 import { ActionDefinition, ExecuteInput, InputField, IntegrationError, RequestFn } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import {
-  fields as createOrUpdateIndividualConstituentFields,
-  perform as performCreateOrUpdateIndividualConstituent
-} from '../createOrUpdateIndividualConstituent'
+import { perform as performCreateOrUpdateIndividualConstituent } from '../createOrUpdateIndividualConstituent'
 import { BlackbaudSkyApi } from '../api'
 import { Gift, StringIndexedObject } from '../types'
-import { buildConstituentPayloadFromPayload, buildGiftDataFromPayload } from '../utils'
+import {
+  augmentFieldsWithConstituentFields,
+  buildConstituentPayloadFromPayload,
+  buildGiftDataFromPayload
+} from '../utils'
 
-const fields: Record<string, InputField> = {
+const fields: Record<string, InputField> = augmentFieldsWithConstituentFields({
   acknowledgement: {
     label: 'Acknowledgement',
     description: 'The gift acknowledgement.',
@@ -213,19 +214,6 @@ const fields: Record<string, InputField> = {
       { label: 'RecurringGift', value: 'RecurringGift' },
       { label: 'RecurringGiftPayment', value: 'RecurringGiftPayment' }
     ]
-  }
-}
-
-Object.keys(createOrUpdateIndividualConstituentFields).forEach((key: string) => {
-  let fieldKey = 'constituent_' + key
-  let fieldLabel = 'Constituent ' + createOrUpdateIndividualConstituentFields[key].label
-  if (key === 'constituent_id') {
-    fieldKey = key
-    fieldLabel = createOrUpdateIndividualConstituentFields[key].label
-  }
-  fields[fieldKey] = {
-    ...createOrUpdateIndividualConstituentFields[key],
-    label: fieldLabel
   }
 })
 

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/index.ts
@@ -5,6 +5,8 @@ import { RefreshTokenResponse } from './types'
 import createGift from './createGift'
 import createOrUpdateIndividualConstituent from './createOrUpdateIndividualConstituent'
 
+import createConstituentAction from './createConstituentAction'
+
 const destination: DestinationDefinition<Settings> = {
   name: "Blackbaud Raiser's Edge NXT",
   slug: 'actions-blackbaud-raisers-edge-nxt',
@@ -56,7 +58,8 @@ const destination: DestinationDefinition<Settings> = {
 
   actions: {
     createGift,
-    createOrUpdateIndividualConstituent
+    createOrUpdateIndividualConstituent,
+    createConstituentAction
   }
 }
 

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/types/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/types/index.ts
@@ -139,3 +139,24 @@ export interface RecurringGiftSchedule {
   frequency: string
   start_date: string | number
 }
+
+export interface ConstituentAction {
+  constituent_id: string
+  date: string | number
+  category: string
+  completed?: boolean
+  completed_date?: string | number
+  description?: string
+  direction?: string
+  end_time?: string
+  fundraisers?: string[]
+  location?: string
+  opportunity_id?: string
+  outcome?: string
+  priority?: string
+  start_time?: string
+  status?: string
+  summary?: string
+  type?: string
+  author?: string
+}

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/utils/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/utils/index.ts
@@ -237,6 +237,7 @@ export const buildConstituentActionDataFromPayload = (constituentId: string, pay
     description: payload.description,
     direction: payload.direction,
     end_time: payload.end_time,
+    fundraisers: payload.fundraisers,
     location: payload.location,
     opportunity_id: payload.opportunity_id,
     outcome: payload.outcome,
@@ -252,11 +253,6 @@ export const buildConstituentActionDataFromPayload = (constituentId: string, pay
       delete constituentActionData[key as keyof ConstituentAction]
     }
   })
-
-  // create fundraisers array
-  if (payload.fundraisers) {
-    constituentActionData.fundraisers = payload.fundraisers.split(',')
-  }
 
   return constituentActionData
 }

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/utils/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/utils/index.ts
@@ -1,3 +1,4 @@
+import { InputField } from '@segment/actions-core'
 import {
   Address,
   Constituent,
@@ -10,9 +11,10 @@ import {
   Phone,
   StringIndexedObject
 } from '../types'
-import { Payload as CreateOrUpdateIndividualConstituentPayload } from '../createOrUpdateIndividualConstituent/generated-types'
-import { Payload as CreateGiftPayload } from '../createGift/generated-types'
 import { Payload as CreateConstituentAction } from '../createConstituentAction/generated-types'
+import { Payload as CreateGiftPayload } from '../createGift/generated-types'
+import { Payload as CreateOrUpdateIndividualConstituentPayload } from '../createOrUpdateIndividualConstituent/generated-types'
+import { fields as createOrUpdateIndividualConstituentFields } from '../createOrUpdateIndividualConstituent'
 
 export const dateStringToFuzzyDate = (dateString: string | number) => {
   // Ignore timezone
@@ -30,6 +32,22 @@ export const dateStringToFuzzyDate = (dateString: string | number) => {
       y: date.getUTCFullYear().toString()
     }
   }
+}
+
+export const augmentFieldsWithConstituentFields = (fields: Record<string, InputField>) => {
+  Object.keys(createOrUpdateIndividualConstituentFields).forEach((key: string) => {
+    let fieldKey = 'constituent_' + key
+    let fieldLabel = 'Constituent ' + createOrUpdateIndividualConstituentFields[key].label
+    if (key === 'constituent_id') {
+      fieldKey = key
+      fieldLabel = createOrUpdateIndividualConstituentFields[key].label
+    }
+    fields[fieldKey] = {
+      ...createOrUpdateIndividualConstituentFields[key],
+      label: fieldLabel
+    }
+  })
+  return fields
 }
 
 export const splitConstituentPayload = (payload: CreateOrUpdateIndividualConstituentPayload) => {

--- a/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/utils/index.ts
+++ b/packages/destination-actions/src/destinations/blackbaud-raisers-edge-nxt/utils/index.ts
@@ -1,6 +1,7 @@
 import {
   Address,
   Constituent,
+  ConstituentAction,
   Email,
   Gift,
   GiftAcknowledgement,
@@ -11,6 +12,7 @@ import {
 } from '../types'
 import { Payload as CreateOrUpdateIndividualConstituentPayload } from '../createOrUpdateIndividualConstituent/generated-types'
 import { Payload as CreateGiftPayload } from '../createGift/generated-types'
+import { Payload as CreateConstituentAction } from '../createConstituentAction/generated-types'
 
 export const dateStringToFuzzyDate = (dateString: string | number) => {
   // Ignore timezone
@@ -204,6 +206,41 @@ export const buildGiftDataFromPayload = (constituentId: string, payload: CreateG
   }
 
   return giftData
+}
+
+export const buildConstituentActionDataFromPayload = (constituentId: string, payload: CreateConstituentAction) => {
+  // data for constituent action call
+  const constituentActionData: Partial<ConstituentAction> = {
+    constituent_id: constituentId,
+    date: payload.date,
+    category: payload.category,
+    completed: payload.completed,
+    completed_date: payload.completed_date,
+    description: payload.description,
+    direction: payload.direction,
+    end_time: payload.end_time,
+    location: payload.location,
+    opportunity_id: payload.opportunity_id,
+    outcome: payload.outcome,
+    priority: payload.priority,
+    start_time: payload.start_time,
+    status: payload.status,
+    summary: payload.summary,
+    type: payload.type,
+    author: payload.author
+  }
+  Object.keys(constituentActionData).forEach((key) => {
+    if (!constituentActionData[key as keyof ConstituentAction]) {
+      delete constituentActionData[key as keyof ConstituentAction]
+    }
+  })
+
+  // create fundraisers array
+  if (payload.fundraisers) {
+    constituentActionData.fundraisers = payload.fundraisers.split(',')
+  }
+
+  return constituentActionData
 }
 
 export const filterObjectListByMatchFields = (


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR updates the Blackbaud Raiser's Edge NXT Destination to add the "Create Constituent Action" Action.
Similar to the "Create Gift" Action, if a constituent ID is not provided, a new one will be created if other constituent fields are provided. 

Example resolved event payload:
```
{
  "date": "2023-03-03T21:35:02.794Z",
  "category": "Email",
  "completed": true,
  "completed_date": "2023-03-03T21:35:02.794Z",
  "description": "Signed Petition",
  "direction": "Inbound",
  "fundraisers": [
    "192"
  ],
  "priority": "Normal",
  "summary": "Signed Petition"
  "constituent_id": "625960"
}
```



## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
